### PR TITLE
Refactor URL navigation to use relative paths

### DIFF
--- a/pages/login_page.js
+++ b/pages/login_page.js
@@ -25,7 +25,7 @@ export class LoginPage {
     }
 
     async gotoLoginPage() {
-        await this.page.goto('https://staging.jarokelo.hu/bejelentkezes');
+        await this.page.goto('/bejelentkezes');
     }
 
     async login(email, password) {

--- a/pages/registration_page.js
+++ b/pages/registration_page.js
@@ -25,6 +25,6 @@ export class RegistrationPage {
     }
 
     async gotoRegistrationPage() {
-        await this.page.goto('https://staging.jarokelo.hu/regisztracio');
+        await this.page.goto('/regisztracio');
     }
 }

--- a/tests/auth.setup.js
+++ b/tests/auth.setup.js
@@ -1,9 +1,11 @@
 import { test as setup, expect } from '@playwright/test';
 import { PROTECTED_URLS, PUBLIC_URLS } from './urls';
 import dotenv from 'dotenv';
+import config from '../playwright.config.js';
 
 dotenv.config();
 const TEN_SECONDS = 10_000;
+const baseURL = config.use.baseURL;
 
 const AUTH = {
     admin: {
@@ -35,7 +37,7 @@ const AUTH = {
 async function confirmAdminLogin(page) {
     await page.waitForURL('citizen')
 
-    expect(page.url()).toBe(process.env.BASE_URL + 'citizen');
+    expect(page.url()).toBe(baseURL + 'citizen');
 }
 
 async function confirmUserLogin(page) {

--- a/tests/login_tests.spec.js
+++ b/tests/login_tests.spec.js
@@ -3,10 +3,11 @@ import { LoginPage } from '../pages/login_page';
 import { expect, test } from '@playwright/test';
 import { PROTECTED_URLS, PUBLIC_URLS } from './urls';
 import dotenv from 'dotenv';
+import config from '../playwright.config.js';
 
 dotenv.config();
 
-const BASE_URL = process.env.BASE_URL;
+const BASE_URL = config.use.baseURL;
 const EMPTY_FIELD = '';
 const VALID_EMAIL = process.env.USER_EMAIL
 const VALID_PASSWORD = process.env.USER_PASSWORD;

--- a/tests/page_load.spec.js
+++ b/tests/page_load.spec.js
@@ -2,9 +2,10 @@ import { expect, test } from '@playwright/test';
 import { ADMIN_URLS, PROTECTED_URLS, PUBLIC_URLS, SUPER_ADMIN_URLS } from './urls';
 import dotenv from 'dotenv';
 import fs from 'fs';
+import config from '../playwright.config.js';
 
 dotenv.config();
-const baseURL = process.env.BASE_URL;
+const baseURL = config.use.baseURL;
 
 test.describe('Public Page Load Tests', () => {
     for (const [pageName, url] of Object.entries(PUBLIC_URLS)) {

--- a/tests/problem_reporting_tests.spec.js
+++ b/tests/problem_reporting_tests.spec.js
@@ -39,7 +39,7 @@ test('Automated report', async ({ page }, testInfo) => {
     await page.setInputFiles('input[type="file"]', picturePath);
     await reportingPage.submitButton.click();
 
-    await page.waitForURL('https://staging.jarokelo.hu/problema-bejelentese/sikeres?scenario=default', { timeout: 2200 });
+    await page.waitForURL('/problema-bejelentese/sikeres?scenario=default', { timeout: 2200 });
 
     console.log(`Selected category: ${randomCategory}`, `Selected city: ${randomCity}`);
     testInfo.annotations.push({ type: 'SelectedCategory', description: randomCategory });


### PR DESCRIPTION
Relativizálva lettek az útvonalak, mindenhol egységesen a playwright.config-ban meghatározott baseURL használatával.