### PR TITLE
Add waitForLoadState to ensure network idle before URL validation

### DIFF
--- a/tests/main_page_elements_navigation_tests.spec.js
+++ b/tests/main_page_elements_navigation_tests.spec.js
@@ -3,6 +3,7 @@ import { MainPage } from "../pages/main_page";
 import config from '../playwright.config.js';
 
 const baseURL = config.use.baseURL;
+const FIVE_SECONDS = 5_000;
 
 test.beforeEach(async ({ page }) => {
     const Main = new MainPage(page);
@@ -161,7 +162,7 @@ test.describe("Same page navigation test", () => {
                 }
             }
 
-            await page.waitForLoadState("networkidle");
+            await page.waitForLoadState("networkidle", { timeout: FIVE_SECONDS });
 
             const pageUrl = page.url();
             expect(pageUrl).toBe(element.expectedUrl);


### PR DESCRIPTION
Hozzáadtam a same page navigation teszthez azt a várakoztatást, ami addig vár amíg a böngészőben nincs több aktív hálózati kérés. Lehet, hogy ennek is kellene adni egy timeout időt, nehogy túl sokáig várjon ha gond van?