### PR TITLE
Update baseURL to use process.env.BASE_URL

### DIFF
--- a/playwright.config.js
+++ b/playwright.config.js
@@ -2,6 +2,9 @@
 import { defineConfig, devices } from '@playwright/test';
 import fs from 'fs';
 import path from 'path';
+import dotenv from 'dotenv';
+
+dotenv.config();
 
 /**
  * Read environment variables from file.
@@ -27,7 +30,7 @@ module.exports = defineConfig({
     /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
     use: {
         /* Base URL to use in actions like `await page.goto('/')`. */
-        baseURL: 'https://staging.jarokelo.hu/',
+        baseURL: process.env.BASE_URL,
 
         /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
         trace: 'on-first-retry',


### PR DESCRIPTION
A playwright.congig.js fileban a baseURL most már a .env-ből jön.