### PR TITLE
Remove NewsletterSubscribeForm from MainPage and UI elements visibility test

### DIFF
--- a/pages/main_page.js
+++ b/pages/main_page.js
@@ -35,7 +35,6 @@ export class MainPage {
         this.hundredThousandArticle = page.locator('xpath = /html/body / main / section / article');
         this.reportProblemLargeButton = page.getByRole('link', { name: 'Bejelentek egy problémát' });
         this.indexReportsDataContainer = page.locator('id=index-reports');
-        this.NewsletterSubscribeForm = page.locator('id=mc_embed_shell');
         this.supportBox = page.locator('div').filter({ hasText: 'Támogasd a Járókelő működését' }).first();
         this.supportBoxMedia = page.getByRole('main').locator('iframe').contentFrame().locator('.ytp-cued-thumbnail-overlay-image');
         this.applicationBox = page.locator('div').filter({ hasText: 'Járókelő a mobilodon Használd' }).first();

--- a/tests/UI_tests/main_page_elements_visibility_test.spec.js
+++ b/tests/UI_tests/main_page_elements_visibility_test.spec.js
@@ -44,7 +44,6 @@ test.describe('UI Elements Visibility', () => {
         { name: 'hundredThousandArticle', action: null },
         { name: 'reportProblemLargeButton', action: null },
         { name: 'indexReportsDataContainer', action: null },
-        { name: 'NewsletterSubscribeForm', action: null },
         { name: 'supportBox', action: null },
         { name: 'supportBoxMedia', action: null },
         { name: 'applicationBox', action: null },


### PR DESCRIPTION
Lekerült az oldalról a hírlevél feliratkozás lehetősége, ezért itt a tesztkódból is kikerült.